### PR TITLE
simplify token class definitions

### DIFF
--- a/pretix_eth/network/tokens.py
+++ b/pretix_eth/network/tokens.py
@@ -140,7 +140,7 @@ class L1(IToken):
             token_address=self.ADDRESS,
         )
         uniswap_url = make_uniswap_url(
-            output_currency=self.TOKEN_SYMBOL,
+            output_currency=self.TOKEN_SYMBOL if self.IS_NATIVE_ASSET or self.ADDRESS,
             recipient_address=wallet_address,
             exact_amount=amount_in_token_base_unit,
             input_currency=None,


### PR DESCRIPTION
with such a great and generic helpers,
there is no need repeat the `payment_instructions` method
its only change was if it was using or not the chain_id
and used token address or not

which is all covered in the helpers already