### PR TITLE
trying to display already set settings values

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -86,6 +86,7 @@ class Ethereum(BasePaymentProvider):
             ]
         )
 
+        form_fields['_NETWORKS']._as_type = list
         return form_fields
 
     def get_token_rates_from_admin_settings(self):


### PR DESCRIPTION
You are right it boils down to `initial` values of Django Forms, but all of the form stuff here is handled via Pretix.

I am trying to mimic restricted countries behaviour [1]

[1] https://github.com/pretix/pretix/blob/4c3192f1168e16c443f3d56020afdab1fffe9704/src/pretix/base/payment.py#L381

Not sure if this really works, but wanted to show you the only difference I have found.

refs https://github.com/esPass/pretix-eth-payment-plugin/issues/164